### PR TITLE
Support for MariaDB 10.1.21+ in galera resource agent

### DIFF
--- a/bz1546083-galera-fix-permission-of-temporary-log-file-for-mari.patch
+++ b/bz1546083-galera-fix-permission-of-temporary-log-file-for-mari.patch
@@ -1,0 +1,31 @@
+From 2754db9d03995e944a53e364f304bc7b0b24d75d Mon Sep 17 00:00:00 2001
+From: Damien Ciabrini <dciabrin@redhat.com>
+Date: Thu, 2 Mar 2017 18:41:50 +0100
+Subject: [PATCH] galera: fix permission of temporary log file for mariadb
+ 10.1.21+
+
+Since MariaDB/server@8fcdd6b0ecbb966f4479856efe93a963a7a422f7,
+mysqld_safe relies on a helper subprocess to write into log files.
+This new logging mechanism expects log file to be writable by the
+user configured to run mysqld.
+
+Fix the generation of temporary log file accordingly.
+---
+ heartbeat/galera | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/heartbeat/galera b/heartbeat/galera
+index 0cab9a46..decbaa25 100755
+--- a/heartbeat/galera
++++ b/heartbeat/galera
+@@ -520,6 +520,7 @@ detect_last_commit()
+     last_commit="$(cat ${OCF_RESKEY_datadir}/grastate.dat | sed -n 's/^seqno.\s*\(.*\)\s*$/\1/p')"
+     if [ -z "$last_commit" ] || [ "$last_commit" = "-1" ]; then
+         local tmp=$(mktemp)
++        chown $OCF_RESKEY_user:$OCF_RESKEY_group $tmp
+ 
+         # if we pass here because grastate.dat doesn't exist,
+         # try not to bootstrap from this node if possible
+-- 
+2.14.3
+

--- a/resource-agents.spec
+++ b/resource-agents.spec
@@ -48,7 +48,7 @@
 Name:		resource-agents
 Summary:	Open Source HA Reusable Cluster Resource Scripts
 Version:	3.9.5
-Release:	105%{?dist}_4.8.rdo1
+Release:	105%{?dist}_4.8.rdo2
 License:	GPLv2+, LGPLv2+ and ASL 2.0
 URL:		https://github.com/ClusterLabs/resource-agents
 %if 0%{?fedora} || 0%{?centos_version} || 0%{?rhel}
@@ -244,6 +244,7 @@ Patch183:	bz1524454-ocf_attribute_target-fallback-fix.patch
 Patch184:	bz1535394-NovaEvacuate-add-support-for-keystone-v3-authentication.patch
 Patch185:	bz1537444-sap_redhat_cluster_connector-fix-unknown-gvi-function.patch
 Patch186:	bz1543366-redis-add-support-for-tunneling-replication-traffic.patch
+Patch187:	bz1546083-galera-fix-permission-of-temporary-log-file-for-mari.patch
 
 Obsoletes:	heartbeat-resources <= %{version}
 Provides:	heartbeat-resources = %{version}
@@ -545,6 +546,7 @@ exit 1
 %patch184 -p1
 %patch185 -p1
 %patch186 -p1
+%patch187 -p1
 
 %build
 if [ ! -f configure ]; then
@@ -808,6 +810,11 @@ ccs_update_schema > /dev/null 2>&1 ||:
 %endif
 
 %changelog
+* Fri Feb 16 2018 Damien Ciabrini <dciabrin@redhat.com> - 3.9.5-105_4.8.rdo2
+- galera: fix permission of temporary log file for mariadb
+
+  Resolves: rhbz#1546083
+
 * Thu Feb  8 2018 Damien Ciabrini <dciabrin@redhat.com> - 3.9.5-105_4.8.rdo1
 - redis: add support for tunneling replication traffic
 


### PR DESCRIPTION
In order to use MariaDB 10.1.30 in RDO [1], we must backport
a fix in resource-agents [2].

Build a package for RDO ahead of time before the official RHEL
fix ships and is replicated in CentOS.

[1] https://review.rdoproject.org/r/#/c/11342/
[2] https://bugzilla.redhat.com/show_bug.cgi?id=1546083